### PR TITLE
Generating sitemaps for multiple sites

### DIFF
--- a/controllers/SitemapController.php
+++ b/controllers/SitemapController.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Pimcoresitemapplugin_SitemapController
+ *
+ * @author Yann Weyer
+ */
+class Pimcoresitemapplugin_SitemapController extends \Pimcore\Controller\Action\Frontend
+{
+
+    public function viewAction()
+    {
+        // Default filename
+        $filename = 'sitemap.xml';
+
+        // Special case: subsite in the tree
+        if (Site::isSiteRequest()) {
+            $site = Site::getCurrentSite();
+            $filename = $site->getMainDomain() . '.xml';
+        }
+
+        // Outputting the XML
+        header('Content-Type: text/xml');
+        readfile($filename);
+        exit;
+    }
+}

--- a/controllers/SitemapController.php
+++ b/controllers/SitemapController.php
@@ -5,23 +5,26 @@
  *
  * @author Yann Weyer
  */
+
+use Byng\Pimcore\Sitemap\SitemapPlugin as SitemapPlugin;
+
 class Pimcoresitemapplugin_SitemapController extends \Pimcore\Controller\Action\Frontend
 {
 
     public function viewAction()
     {
         // Default filename
-        $filename = 'sitemap.xml';
+        $filename = '/sitemap.xml';
 
         // Special case: subsite in the tree
         if (Site::isSiteRequest()) {
             $site = Site::getCurrentSite();
-            $filename = $site->getMainDomain() . '.xml';
+            $filename = '/' . $site->getMainDomain() . '.xml';
         }
 
         // Outputting the XML
         header('Content-Type: text/xml');
-        readfile($filename);
+        readfile(PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER . $filename);
         exit;
     }
 }

--- a/controllers/SitemapController.php
+++ b/controllers/SitemapController.php
@@ -28,15 +28,22 @@ final class Pimcoresitemapplugin_SitemapController extends Frontend
     {
         // Special case: subsite in the tree
         if (isset($this->document) && $site = \Pimcore\Tool\Frontend::getSiteForDocument($this->document)) {
-            $filename = '/' . $site->getMainDomain() . '.xml';
+            $domain = $site->getMainDomain();
         } else {
             // Default filename
-            $filename = '/' . \Pimcore\Config::getSystemConfig()->get("general")->get("domain") . '.xml';
+            $domain = \Pimcore\Config::getSystemConfig()->get("general")->get("domain");
         }
 
-        // Outputting the XML
+        $filename = SITEMAP_PLUGIN_FOLDER . '/' . $domain . '.xml';
+
+        // Throw a 404 if there is no sitemap for this domain
+        if (!file_exists($filename)) {
+            throw new Zend_Controller_Action_Exception("Sitemap for domain '$domain' not found, please check the plugin configuration", 404);
+        }
+
+        // Output the XML
         header('Content-Type: text/xml');
-        readfile(SITEMAP_PLUGIN_FOLDER . $filename);
+        readfile($filename);
         exit;
     }
 }

--- a/controllers/SitemapController.php
+++ b/controllers/SitemapController.php
@@ -7,8 +7,9 @@
  */
 
 use Byng\Pimcore\Sitemap\SitemapPlugin as SitemapPlugin;
+use Pimcore\Controller\Action\Frontend as Frontend;
 
-class Pimcoresitemapplugin_SitemapController extends \Pimcore\Controller\Action\Frontend
+final class Pimcoresitemapplugin_SitemapController extends Frontend
 {
 
     /*

--- a/controllers/SitemapController.php
+++ b/controllers/SitemapController.php
@@ -13,13 +13,13 @@ class Pimcoresitemapplugin_SitemapController extends \Pimcore\Controller\Action\
 
     public function viewAction()
     {
-        // Default filename
-        $filename = '/sitemap.xml';
-
         // Special case: subsite in the tree
         if (Site::isSiteRequest()) {
             $site = Site::getCurrentSite();
             $filename = '/' . $site->getMainDomain() . '.xml';
+        } else {
+            // Default filename
+            $filename = '/'. \Pimcore\Config::getSystemConfig()->get("general")->get("domain") . '.xml';
         }
 
         // Outputting the XML

--- a/controllers/SitemapController.php
+++ b/controllers/SitemapController.php
@@ -36,7 +36,7 @@ final class Pimcoresitemapplugin_SitemapController extends Frontend
 
         // Outputting the XML
         header('Content-Type: text/xml');
-        readfile(PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER . $filename);
+        readfile(SITEMAP_PLUGIN_FOLDER . $filename);
         exit;
     }
 }

--- a/controllers/SitemapController.php
+++ b/controllers/SitemapController.php
@@ -1,9 +1,16 @@
 <?php
 
 /**
- * Pimcoresitemapplugin_SitemapController
+ * This file is part of the pimcore-sitemap-plugin package.
  *
- * @author Yann Weyer
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 use Byng\Pimcore\Sitemap\SitemapPlugin as SitemapPlugin;
@@ -12,8 +19,10 @@ use Pimcore\Controller\Action\Frontend as Frontend;
 final class Pimcoresitemapplugin_SitemapController extends Frontend
 {
 
-    /*
+    /**
      * Shows the sitemap.xml of the currently visited website
+     *
+     * @return void
      */
     public function viewAction()
     {
@@ -22,7 +31,7 @@ final class Pimcoresitemapplugin_SitemapController extends Frontend
             $filename = '/' . $site->getMainDomain() . '.xml';
         } else {
             // Default filename
-            $filename = '/'. \Pimcore\Config::getSystemConfig()->get("general")->get("domain") . '.xml';
+            $filename = '/' . \Pimcore\Config::getSystemConfig()->get("general")->get("domain") . '.xml';
         }
 
         // Outputting the XML

--- a/controllers/SitemapController.php
+++ b/controllers/SitemapController.php
@@ -11,11 +11,13 @@ use Byng\Pimcore\Sitemap\SitemapPlugin as SitemapPlugin;
 class Pimcoresitemapplugin_SitemapController extends \Pimcore\Controller\Action\Frontend
 {
 
+    /*
+     * Shows the sitemap.xml of the currently visited website
+     */
     public function viewAction()
     {
         // Special case: subsite in the tree
-        if (Site::isSiteRequest()) {
-            $site = Site::getCurrentSite();
+        if (isset($this->document) && $site = \Pimcore\Tool\Frontend::getSiteForDocument($this->document)) {
             $filename = '/' . $site->getMainDomain() . '.xml';
         } else {
             // Default filename

--- a/install/config.xml
+++ b/install/config.xml
@@ -4,6 +4,7 @@
     <!--
         <site>
           <rootId>1</rootId>
+          <rootPath>subsite</rootPath>
           <protocol>https</protocol>
           <domain>www.domain.com</domain>
         </site>

--- a/install/config.xml
+++ b/install/config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<zend-config>
+    <sites>
+    <!--
+        <site>
+          <rootId>1</rootId>
+          <protocol>https</protocol>
+          <domain>www.domain.com</domain>
+        </site>
+     -->
+    </sites>
+</zend-config>

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -71,7 +71,7 @@ final class SitemapGenerator
     public function generateXml()
     {
         // Retrieve site trees
-        $config = new \Zend_Config_Xml(SitemapPlugin::CONFIGURATION_FILE);
+        $config = new \Zend_Config_Xml(SITEMAP_CONFIGURATION_FILE);
         $siteRoots = $config->get('sites')->get('site');
 
         // Build siteRoots ID array
@@ -114,7 +114,7 @@ final class SitemapGenerator
         $this->addUrlChild($rootDocument);
         $this->listAllChildren($rootDocument);
 
-        $this->xml->asXML(PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER . '/' . $this->host->domain . '.xml');
+        $this->xml->asXML(SITEMAP_PLUGIN_FOLDER . '/' . $this->host->domain . '.xml');
     }
 
     /**

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -51,7 +51,7 @@ final class SitemapGenerator
     /**
      * @var array
      */
-    private $sitesRoots = array();
+    private $sitesRoots = [];
 
 
     /**

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -82,7 +82,7 @@ final class SitemapGenerator
         $notifySearchEngines = Config::getSystemConfig()->get("general")->get("environment") === "production";
         foreach($this->sitesRoots as $siteRootID => $siteRootDomain){
             $this->generateSiteXml($siteRootID, $siteRootDomain);
-            
+
             if ($notifySearchEngines)
                 $this->notifySearchEngines('https://' . $siteRootDomain);
         }
@@ -175,7 +175,7 @@ final class SitemapGenerator
     {
         $googleNotifier = new GoogleNotifier();
 
-        if ($googleNotifier->notify($domain = null)) {
+        if ($googleNotifier->notify($domain)) {
             echo "Google has been notified \n";
         } else {
             echo "Google has not been notified \n";

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -93,8 +93,8 @@ final class SitemapGenerator
     /**
      * Generate a sitemap xml file for a defined site, with a specific hostUrl
      *
-     * @param $rootId
-     * @param $hostUrl
+     * @param int $rootId
+     * @param string $hostUrl
      * @return string
      */
     private function generateSiteXml($rootId, $hostUrl)
@@ -127,8 +127,9 @@ final class SitemapGenerator
         /* @var $child Document */
         foreach ($children as $child) {
             // If we are on a siteRoot, skipping it (handled in a different sitemap)
-            if (array_key_exists($child->getId(), $this->sitesRoots))
+            if (array_key_exists($child->getId(), $this->sitesRoots)) {
                 continue;
+            }
 
             $this->addUrlChild($child);
             $this->listAllChildren($child);

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -89,6 +89,30 @@ final class SitemapGenerator
     }
 
     /**
+     * Generate a sitemap xml file for a defined site, with a specific hostUrl
+     *
+     * @param $rootId
+     * @param $hostUrl
+     * @return string
+     */
+    private function generateSiteXml($rootId, $hostUrl)
+    {
+        $this->xml = new SimpleXMLElement(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>'
+        );
+
+        // Set current hostUrl
+        $this->hostUrl = $hostUrl;
+
+        $rootDocument = Document::getById($rootId);
+        $this->addUrlChild($rootDocument);
+        $this->listAllChildren($rootDocument);
+
+        $this->xml->asXML(PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER . '/' . $hostUrl .'.xml');
+    }
+
+    /**
      * Finds all the children of a document recursively
      *
      * @param Document $document
@@ -156,20 +180,4 @@ final class SitemapGenerator
         }
     }
 
-    private function generateSiteXml($parentId, $hostUrl)
-    {
-        $this->xml = new SimpleXMLElement(
-            '<?xml version="1.0" encoding="UTF-8"?>'
-            . '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>'
-        );
-
-        // Set current hostUrl
-        $this->hostUrl = $hostUrl;
-
-        $rootDocument = Document::getById($parentId);
-        $this->addUrlChild($rootDocument);
-        $this->listAllChildren($rootDocument);
-
-        $this->xml->asXML(PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER . '/' . $hostUrl .'.xml');
-    }
 }

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -72,7 +72,7 @@ final class SitemapGenerator
 
         // Build siteRoots table: [ ID => Domain ]
         /* @var Site $siteRoot */
-        foreach ($siteRoots as $siteRoot){
+        foreach ($siteRoots as $siteRoot) {
             $this->sitesRoots[$siteRoot->getRootId()] = $siteRoot->getMainDomain();
         }
 
@@ -80,7 +80,7 @@ final class SitemapGenerator
         $this->sitesRoots[1] = Config::getSystemConfig()->get("general")->get("domain");
 
         $notifySearchEngines = Config::getSystemConfig()->get("general")->get("environment") === "production";
-        foreach($this->sitesRoots as $siteRootID => $siteRootDomain){
+        foreach ($this->sitesRoots as $siteRootID => $siteRootDomain) {
             $this->generateSiteXml($siteRootID, $siteRootDomain);
 
             if ($notifySearchEngines) {
@@ -111,7 +111,7 @@ final class SitemapGenerator
         $this->addUrlChild($rootDocument);
         $this->listAllChildren($rootDocument);
 
-        $this->xml->asXML(PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER . '/' . $hostUrl .'.xml');
+        $this->xml->asXML(PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER . '/' . $hostUrl . '.xml');
     }
 
     /**
@@ -127,7 +127,7 @@ final class SitemapGenerator
         /* @var $child Document */
         foreach ($children as $child) {
             // If we are on a siteRoot, skipping it (handled in a different sitemap)
-            if(array_key_exists($child->getId(), $this->sitesRoots))
+            if (array_key_exists($child->getId(), $this->sitesRoots))
                 continue;
 
             $this->addUrlChild($child);

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -17,7 +17,6 @@ namespace Byng\Pimcore\Sitemap\Generator;
 
 use Byng\Pimcore\Sitemap\Gateway\DocumentGateway;
 use Byng\Pimcore\Sitemap\Notifier\GoogleNotifier;
-use Byng\Pimcore\Sitemap\SitemapPlugin;
 use Pimcore\Config;
 use Pimcore\Model\Document;
 use SimpleXMLElement;
@@ -35,7 +34,7 @@ final class SitemapGenerator
     private $hostUrl;
 
     /**
-     * @var \Zend_Config
+     * @var SimpleXMLElement
      */
     private $host;
 
@@ -71,11 +70,10 @@ final class SitemapGenerator
     public function generateXml()
     {
         // Retrieve site trees
-        $config = new \Zend_Config_Xml(SITEMAP_CONFIGURATION_FILE);
-        $siteRoots = $config->get('sites')->get('site');
+        $config = simplexml_load_file(SITEMAP_CONFIGURATION_FILE);
+        $siteRoots = $config->sites->site;
 
         // Build siteRoots ID array
-        /* @var \Zend_Config $siteRoot */
         foreach ($siteRoots as $siteRoot) {
             $this->sitesRoots[(int)$siteRoot->rootId] = $siteRoot;
         }

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -72,7 +72,7 @@ final class SitemapGenerator
             $this->addUrlChild($rootDocument);
             $this->listAllChildren($rootDocument);
         }
-        $this->xml->asXML(PIMCORE_DOCUMENT_ROOT . "/sitemap.xml");
+        $this->xml->asXML(PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER . "/sitemap.xml");
 
         if (Config::getSystemConfig()->get("general")->get("environment") === "production") {
             $this->notifySearchEngines();

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -103,7 +103,7 @@ final class SitemapGenerator
         );
 
         // Set current hostUrl
-        $this->hostUrl = $hostUrl;
+        $this->hostUrl = 'https://' . $hostUrl;
 
         $rootDocument = Document::getById($rootId);
         $this->addUrlChild($rootDocument);

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -148,14 +148,18 @@ final class SitemapGenerator
         if (
             $document instanceof Document\Page &&
             !$document->getProperty("sitemap_exclude")
-            && !array_key_exists($document->getId(), $this->sitesRoots)
         ) {
             $fullPath = $document->getFullPath();
 
             // Remove the site path (if any) from the full path
-            $rootPath = $this->host->rootPath;
-            if(!is_null($rootPath) && strpos($fullPath, '/' . $rootPath . '/') === 0){
-                $fullPath = str_replace('/' . $rootPath, '', $fullPath);
+            $rootPath = (string)$this->host->rootPath;
+            if (!empty($rootPath) && strpos($fullPath, '/' . $rootPath) === 0) {
+                if ($fullPath === '/' . $rootPath) {
+                    // Special case for the homepage
+                    $fullPath = '';
+                } else {
+                    $fullPath = str_replace('/' . $rootPath . '/', '/', $fullPath);
+                }
             }
 
             echo $this->hostUrl . $fullPath . "\n";

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -153,9 +153,17 @@ final class SitemapGenerator
             !$document->getProperty("sitemap_exclude")
             && !array_key_exists($document->getId(), $this->sitesRoots)
         ) {
-            echo $this->hostUrl . $document->getFullPath() . "\n";
+            $fullPath = $document->getFullPath();
+
+            // Remove the site path (if any) from the full path
+            $rootPath = $this->host->rootPath;
+            if(!is_null($rootPath) && strpos($fullPath, '/' . $rootPath . '/') === 0){
+                $fullPath = str_replace('/' . $rootPath, '', $fullPath);
+            }
+
+            echo $this->hostUrl . $fullPath . "\n";
             $url = $this->xml->addChild("url");
-            $url->addChild('loc', $this->hostUrl . $document->getFullPath());
+            $url->addChild('loc', $this->hostUrl . $fullPath);
             $url->addChild('lastmod', $this->getDateFormat($document->getModificationDate()));
         }
     }

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -83,6 +83,7 @@ final class SitemapGenerator
             $this->generateSiteXml($siteRootID, $siteRootDomain);
         }
 
+        // @ToDo: should we also notify Google for each subsites sitemaps?
         if (Config::getSystemConfig()->get("general")->get("environment") === "production") {
             $this->notifySearchEngines();
         }

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -79,14 +79,14 @@ final class SitemapGenerator
         // Also append the default tree
         $this->sitesRoots[1] = Config::getSystemConfig()->get("general")->get("domain");
 
+        $notifySearchEngines = Config::getSystemConfig()->get("general")->get("environment") === "production";
         foreach($this->sitesRoots as $siteRootID => $siteRootDomain){
             $this->generateSiteXml($siteRootID, $siteRootDomain);
+            
+            if ($notifySearchEngines)
+                $this->notifySearchEngines('https://' . $siteRootDomain);
         }
 
-        // @ToDo: should we also notify Google for each subsites sitemaps?
-        if (Config::getSystemConfig()->get("general")->get("environment") === "production") {
-            $this->notifySearchEngines();
-        }
     }
 
     /**
@@ -168,13 +168,14 @@ final class SitemapGenerator
     /**
      * Notify search engines about the sitemap update.
      *
+     * @param string $domain
      * @return void
      */
-    private function notifySearchEngines()
+    private function notifySearchEngines($domain = null)
     {
         $googleNotifier = new GoogleNotifier();
 
-        if ($googleNotifier->notify()) {
+        if ($googleNotifier->notify($domain = null)) {
             echo "Google has been notified \n";
         } else {
             echo "Google has not been notified \n";

--- a/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
+++ b/lib/Byng/Pimcore/Sitemap/Generator/SitemapGenerator.php
@@ -83,8 +83,9 @@ final class SitemapGenerator
         foreach($this->sitesRoots as $siteRootID => $siteRootDomain){
             $this->generateSiteXml($siteRootID, $siteRootDomain);
 
-            if ($notifySearchEngines)
+            if ($notifySearchEngines) {
                 $this->notifySearchEngines('https://' . $siteRootDomain);
+            }
         }
 
     }

--- a/lib/Byng/Pimcore/Sitemap/Notifier/GoogleNotifier.php
+++ b/lib/Byng/Pimcore/Sitemap/Notifier/GoogleNotifier.php
@@ -27,12 +27,12 @@ final class GoogleNotifier implements SitemapNotifierInterface
     /**
      * {@inheritdoc}
      */
-    public function notify()
+    public function notify($domain = null)
     {
         $ch = curl_init(
             sprintf(
                 "http://www.google.com/webmasters/sitemaps/ping?sitemap=%s/sitemap.xml",
-                Config::getSystemConfig()->get("general")->get("domain")
+                $domain ?: Config::getSystemConfig()->get("general")->get("domain")
             )
         );
 

--- a/lib/Byng/Pimcore/Sitemap/Notifier/SitemapNotifierInterface.php
+++ b/lib/Byng/Pimcore/Sitemap/Notifier/SitemapNotifierInterface.php
@@ -25,7 +25,8 @@ interface SitemapNotifierInterface
     /**
      * Notify something that the sitemap has been updated.
      *
+     * @param string $domain the default domain if empty
      * @return bool
      */
-    public function notify();
+    public function notify($domain = null);
 }

--- a/lib/Byng/Pimcore/Sitemap/Plugin/Installer.php
+++ b/lib/Byng/Pimcore/Sitemap/Plugin/Installer.php
@@ -25,11 +25,12 @@ use Pimcore\Model\Staticroute;
  * Class Installer
  *
  * @package Byng\Pimcore\Sitemap\Plugin
+ * @author Yann Weyer <yann.weyer@orderbird.com>
  */
 final class Installer
 {
     /**
-     * Create predefined properties to be used in the admin interface
+     * Creates predefined properties to be used in the admin interface
      */
     public function createProperties()
     {
@@ -49,7 +50,7 @@ final class Installer
     }
 
     /**
-     * Delete predefined properties
+     * Deletes predefined properties
      */
     public function deleteProperties()
     {
@@ -58,11 +59,10 @@ final class Installer
     }
 
     /**
-     * Set up the redirect rules used to display the appropriate sitemap file
+     * Creates the redirect rules used to display the appropriate sitemap file
      */
     public function createRedirectRule()
     {
-        // Create redirect rule
         $route = Staticroute::create();
         $route->setName('sitemap')
             ->setPattern('/^\/sitemap\.xml$/')
@@ -74,7 +74,7 @@ final class Installer
     }
 
     /**
-     * Remove the redirect rule
+     * Removes the redirect rule
      */
     public function deleteRedirectRule()
     {
@@ -83,7 +83,7 @@ final class Installer
     }
 
     /**
-     * Create the sitemap folder
+     * Creates the sitemap folder
      */
     public function createSitemapFolder()
     {
@@ -94,16 +94,15 @@ final class Installer
     }
 
     /**
-     * Delete the sitemap folder and its children
+     * Deletes the sitemap folder and its children
      */
     public function deleteSitemapFolder()
     {
-        $sitemapFolder = SITEMAP_PLUGIN_FOLDER;
-        if (is_dir($sitemapFolder)) {
-            if (!is_dir_empty($sitemapFolder)) {
-                array_map('unlink', glob($sitemapFolder . '/*'));
+        if (is_dir(SITEMAP_PLUGIN_FOLDER)) {
+            if (!is_dir_empty(SITEMAP_PLUGIN_FOLDER)) {
+                array_map('unlink', glob(SITEMAP_PLUGIN_FOLDER . '/*'));
             }
-            rmdir($sitemapFolder);
+            rmdir(SITEMAP_PLUGIN_FOLDER);
         }
     }
 
@@ -120,20 +119,19 @@ final class Installer
         $config = new \Zend_Config_Xml(PIMCORE_PLUGINS_PATH . '/PimcoreSitemapPlugin/install/config.xml', null, ['allowModifications' => true]);
         $config->sites = ['site' => $sites];
 
-        $configFile = SITEMAP_CONFIGURATION_FILE;
-        if (!is_dir(dirname($configFile))) {
-            if (!@mkdir(dirname($configFile), 0777, true)) {
+        if (!is_dir(dirname(SITEMAP_CONFIGURATION_FILE))) {
+            if (!@mkdir(dirname(SITEMAP_CONFIGURATION_FILE), 0777, true)) {
                 throw new \Exception('Sitemap: Unable to create plugin config directory');
             }
         }
 
         $configWriter = new \Zend_Config_Writer_Xml();
         $configWriter->setConfig($config);
-        $configWriter->write($configFile);
+        $configWriter->write(SITEMAP_CONFIGURATION_FILE);
     }
 
     /**
-     * Delete the configuration file
+     * Deletes the configuration file
      */
     public function deleteConfigFile()
     {
@@ -167,11 +165,10 @@ final class Installer
         // Build siteRoots table: [ ID => FQDN ]
         /* @var Site $siteRoot */
         foreach ($siteRoots as $siteRoot) {
-            $protocol = $this->getProtocolForDomain($siteRoot->getMainDomain(), $client);
             $sitesMap[] = [
                 'rootId' => $siteRoot->getRootId(),
                 'rootPath' => trim($siteRoot->getRootPath(), '/'),
-                'protocol' => $protocol,
+                'protocol' => $this->getProtocolForDomain($siteRoot->getMainDomain(), $client),
                 'domain' => $siteRoot->getMainDomain()
             ];
         }
@@ -181,7 +178,7 @@ final class Installer
 
 
     /**
-     * Test https for a domain name and returns either https or http depending on the server answer
+     * Tests https for a domain name and returns either https or http depending on the server answer
      * @param $domain
      * @param \Zend_Http_Client|null $client
      * @return string

--- a/lib/Byng/Pimcore/Sitemap/Plugin/Installer.php
+++ b/lib/Byng/Pimcore/Sitemap/Plugin/Installer.php
@@ -88,8 +88,8 @@ final class Installer
     public function createSitemapFolder()
     {
         // Create sitemap folder (if doesn't exist already)
-        if (!is_dir(PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER)) {
-            mkdir(PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER, 0777, true);
+        if (!is_dir(SITEMAP_PLUGIN_FOLDER)) {
+            mkdir(SITEMAP_PLUGIN_FOLDER, 0777, true);
         }
     }
 
@@ -98,7 +98,7 @@ final class Installer
      */
     public function deleteSitemapFolder()
     {
-        $sitemapFolder = PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER;
+        $sitemapFolder = SITEMAP_PLUGIN_FOLDER;
         if (is_dir($sitemapFolder)) {
             if (!is_dir_empty($sitemapFolder)) {
                 array_map('unlink', glob($sitemapFolder . '/*'));
@@ -120,7 +120,7 @@ final class Installer
         $config = new \Zend_Config_Xml(PIMCORE_PLUGINS_PATH . '/PimcoreSitemapPlugin/install/config.xml', null, ['allowModifications' => true]);
         $config->sites = ['site' => $sites];
 
-        $configFile = SitemapPlugin::CONFIGURATION_FILE;
+        $configFile = SITEMAP_CONFIGURATION_FILE;
         if (!is_dir(dirname($configFile))) {
             if (!@mkdir(dirname($configFile), 0777, true)) {
                 throw new \Exception('Sitemap: Unable to create plugin config directory');
@@ -137,8 +137,8 @@ final class Installer
      */
     public function deleteConfigFile()
     {
-        if (file_exists(SitemapPlugin::CONFIGURATION_FILE)) {
-            unlink(SitemapPlugin::CONFIGURATION_FILE);
+        if (file_exists(SITEMAP_CONFIGURATION_FILE)) {
+            unlink(SITEMAP_CONFIGURATION_FILE);
         }
     }
 

--- a/lib/Byng/Pimcore/Sitemap/Plugin/Installer.php
+++ b/lib/Byng/Pimcore/Sitemap/Plugin/Installer.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * This file is part of the pimcore-sitemap-plugin package.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Byng\Pimcore\Sitemap\Plugin;
+
+use Byng\Pimcore\Sitemap\SitemapPlugin;
+use Pimcore\Config;
+use Pimcore\Model\Property\Predefined as PredefinedProperty;
+use Pimcore\Model\Site;
+use Pimcore\Model\Staticroute;
+
+/**
+ * Class Installer
+ *
+ * @package Byng\Pimcore\Sitemap\Plugin
+ */
+final class Installer
+{
+    /**
+     * Create predefined properties to be used in the admin interface
+     */
+    public function createProperties()
+    {
+        $data = [
+            "key" => "sitemap_exclude",
+            "name" => "Sitemap: Exclude page",
+            "description" => "Add this property to exclude a page from the sitemap",
+            "ctype" => "document",
+            "type" => "bool",
+            "inheritable" => false,
+            "data" => true
+        ];
+        $property = PredefinedProperty::create();
+        $property->setValues($data);
+
+        $property->save();
+    }
+
+    /**
+     * Delete predefined properties
+     */
+    public function deleteProperties()
+    {
+        $property = PredefinedProperty::getByKey("sitemap_exclude");
+        $property->delete();
+    }
+
+    /**
+     * Set up the redirect rules used to display the appropriate sitemap file
+     */
+    public function createRedirectRule()
+    {
+        // Create redirect rule
+        $route = Staticroute::create();
+        $route->setName('sitemap')
+            ->setPattern('/\/sitemap\.xml/')
+            ->setReverse('/sitemap.xml')
+            ->setModule('PimcoreSitemapPlugin')
+            ->setController('sitemap')
+            ->setAction('view')
+            ->save();
+    }
+
+    /**
+     * Remove the redirect rule
+     */
+    public function deleteRedirectRule()
+    {
+        $route = Staticroute::getByName('sitemap');
+        $route->delete();
+    }
+
+    /**
+     * Create the sitemap folder
+     */
+    public function createSitemapFolder()
+    {
+        // Create sitemap folder (if doesn't exist already)
+        if (!is_dir(PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER)) {
+            mkdir(PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER, 0777, true);
+        }
+    }
+
+    /**
+     * Delete the sitemap folder and its children
+     */
+    public function deleteSitemapFolder()
+    {
+        $sitemapFolder = PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER;
+        if (is_dir($sitemapFolder)) {
+            if (!is_dir_empty($sitemapFolder)) {
+                array_map('unlink', glob($sitemapFolder . '/*'));
+            }
+            rmdir($sitemapFolder);
+        }
+    }
+
+    /**
+     * Creates the configuration file.
+     * @throws \Exception
+     */
+    public function createConfigFile()
+    {
+        // Get Sites FQDN map
+        $sites = $this->getSitesProtocolMap();
+
+        // Create xml config file
+        $config = new \Zend_Config_Xml(PIMCORE_PLUGINS_PATH . '/PimcoreSitemapPlugin/install/config.xml', null, ['allowModifications' => true]);
+        $config->sites = ['site' => $sites];
+
+        $configFile = SitemapPlugin::CONFIGURATION_FILE;
+        if (!is_dir(dirname($configFile))) {
+            if (!@mkdir(dirname($configFile), 0777, true)) {
+                throw new \Exception('Sitemap: Unable to create plugin config directory');
+            }
+        }
+
+        $configWriter = new \Zend_Config_Writer_Xml();
+        $configWriter->setConfig($config);
+        $configWriter->write($configFile);
+    }
+
+    /**
+     * Delete the configuration file
+     */
+    public function deleteConfigFile()
+    {
+        if (file_exists(SitemapPlugin::CONFIGURATION_FILE)) {
+            unlink(SitemapPlugin::CONFIGURATION_FILE);
+        }
+    }
+
+    /**
+     * Lists the Pimcore sites and their properties (used to generate Config file)
+     * @return array
+     */
+    private function getSitesProtocolMap()
+    {
+        $client = new \Zend_Http_Client();
+        $sitesMap = [];
+
+        // Add the main domain
+        $defaultDomain = Config::getSystemConfig()->get("general")->get("domain");
+        $sitesMap[] = [
+            'rootId' => 1,
+            'rootPath' => '',
+            'protocol' => $this->getProtocolForDomain($defaultDomain, $client),
+            'domain' => $defaultDomain
+        ];
+
+        // Retrieve site trees
+        $siteRoots = new Site\Listing();
+        $siteRoots = $siteRoots->load();
+
+        // Build siteRoots table: [ ID => FQDN ]
+        /* @var Site $siteRoot */
+        foreach ($siteRoots as $siteRoot) {
+            $protocol = $this->getProtocolForDomain($siteRoot->getMainDomain(), $client);
+            $sitesMap[] = [
+                'rootId' => $siteRoot->getRootId(),
+                'rootPath' => trim($siteRoot->getRootPath(), '/'),
+                'protocol' => $protocol,
+                'domain' => $siteRoot->getMainDomain()
+            ];
+        }
+
+        return $sitesMap;
+    }
+
+
+    /**
+     * Test https for a domain name and returns either https or http depending on the server answer
+     * @param $domain
+     * @param \Zend_Http_Client|null $client
+     * @return string
+     */
+    private function getProtocolForDomain($domain, \Zend_Http_Client $client = null)
+    {
+        if (!$client) {
+            $client = new \Zend_Http_Client();
+        }
+        $client->setUri('https://' . $domain);
+        try {
+            $client->request();
+            $protocol = $client->getLastResponse()->getStatus() === 200 ? 'https' : 'http';
+        } catch (\Exception $e) {
+            $protocol = 'http';
+        }
+
+        return $protocol;
+    }
+}

--- a/lib/Byng/Pimcore/Sitemap/Plugin/Installer.php
+++ b/lib/Byng/Pimcore/Sitemap/Plugin/Installer.php
@@ -99,8 +99,9 @@ final class Installer
     public function deleteSitemapFolder()
     {
         if (is_dir(SITEMAP_PLUGIN_FOLDER)) {
-            if (!is_dir_empty(SITEMAP_PLUGIN_FOLDER)) {
-                array_map('unlink', glob(SITEMAP_PLUGIN_FOLDER . '/*'));
+            $children = glob(SITEMAP_PLUGIN_FOLDER . '/*');
+            if (count($children) > 0) {
+                array_map('unlink', $children);
             }
             rmdir(SITEMAP_PLUGIN_FOLDER);
         }
@@ -151,12 +152,15 @@ final class Installer
 
         // Add the main domain
         $defaultDomain = Config::getSystemConfig()->get("general")->get("domain");
-        $sitesMap[] = [
-            'rootId' => 1,
-            'rootPath' => '',
-            'protocol' => $this->getProtocolForDomain($defaultDomain, $client),
-            'domain' => $defaultDomain
-        ];
+
+        if($defaultDomain) {
+            $sitesMap[] = [
+                'rootId' => 1,
+                'rootPath' => '',
+                'protocol' => $this->getProtocolForDomain($defaultDomain, $client),
+                'domain' => $defaultDomain
+            ];
+        }
 
         // Retrieve site trees
         $siteRoots = new Site\Listing();

--- a/lib/Byng/Pimcore/Sitemap/Plugin/Installer.php
+++ b/lib/Byng/Pimcore/Sitemap/Plugin/Installer.php
@@ -65,7 +65,7 @@ final class Installer
         // Create redirect rule
         $route = Staticroute::create();
         $route->setName('sitemap')
-            ->setPattern('/\/sitemap\.xml/')
+            ->setPattern('/^\/sitemap\.xml$/')
             ->setReverse('/sitemap.xml')
             ->setModule('PimcoreSitemapPlugin')
             ->setController('sitemap')

--- a/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
+++ b/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
@@ -195,9 +195,13 @@ class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\Plugin
     public static function isInstalled()
     {
         $property = PredefinedProperty::getByKey("sitemap_exclude");
-        if ($property && $property->getId()) {
-            return true;
+        if (!$property || !$property->getId()) {
+            return false;
         }
-        return false;
+        if (!file_exists(self::CONFIGURATION_FILE)) {
+            return false;
+        }
+        return true;
     }
+
 }

--- a/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
+++ b/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
@@ -33,7 +33,7 @@ class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\Plugin
 {
     const MAINTENANCE_JOB_GENERATE_SITEMAP = "create-sitemap";
     const SITEMAP_FOLDER = '/var/plugins/Sitemap';
-    const CONFIGURATION_FILE = PIMCORE_WEBSITE_PATH . '/var/plugins/sitemap/config.xml';
+    const CONFIGURATION_FILE = PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER . '/config.xml';
 
     /**
      * {@inheritdoc}

--- a/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
+++ b/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
@@ -20,6 +20,8 @@ use Pimcore\Model\Property\Predefined as PredefinedProperty;
 use Pimcore\Model\Schedule\Manager\Procedural as ProceduralScheduleManager;
 use Pimcore\Model\Schedule\Maintenance\Job as MaintenanceJob;
 use Byng\Pimcore\Sitemap\Generator\SitemapGenerator;
+use Pimcore\Config;
+use Pimcore\Model\Site;
 use Pimcore\Model\Staticroute;
 
 /**
@@ -31,6 +33,7 @@ class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\Plugin
 {
     const MAINTENANCE_JOB_GENERATE_SITEMAP = "create-sitemap";
     const SITEMAP_FOLDER = '/var/plugins/Sitemap';
+    const CONFIGURATION_FILE = PIMCORE_WEBSITE_PATH . '/var/plugins/sitemap/config.xml';
 
     /**
      * {@inheritdoc}
@@ -82,11 +85,85 @@ class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\Plugin
 
             // Create sitemap folder
             mkdir(PIMCORE_WEBSITE_PATH . self::SITEMAP_FOLDER, 0777, true);
+            // Get Sites FQDN map
+            $sites = self::getSitesProtocolMap();
+
+            // Create xml config file
+            $config = new \Zend_Config_Xml(PIMCORE_PLUGINS_PATH . '/PimcoreSitemapPlugin/install/config.xml', null, ['allowModifications' => true]);
+            $config->sites = ['site' => $sites];
+
+            $configFile = self::CONFIGURATION_FILE;
+            if (!is_dir(dirname($configFile))) {
+                if (!@mkdir(dirname($configFile), 0777, true)) {
+                    throw new \Exception('Sitemap: Unable to create plugin config directory');
+                }
+            }
+
+            $configWriter = new \Zend_Config_Writer_Xml();
+            $configWriter->setConfig($config);
+            $configWriter->write($configFile);
 
             return "Sitemap plugin successfully installed";
         }
 
         return "There was a problem during the installation";
+    }
+
+
+    /**
+     * @return array
+     */
+    public static function getSitesProtocolMap()
+    {
+        $client = new \Zend_Http_Client();
+        $sitesMap = [];
+
+        // Add the main domain
+        $defaultDomain = Config::getSystemConfig()->get("general")->get("domain");
+        $sitesMap[] = [
+            'rootId' => 1,
+            'protocol' => self::getProtocolForDomain($defaultDomain, $client),
+            'domain' => $defaultDomain
+        ];
+
+        // Retrieve site trees
+        $siteRoots = new Site\Listing();
+        $siteRoots = $siteRoots->load();
+
+        // Build siteRoots table: [ ID => FQDN ]
+        /* @var Site $siteRoot */
+        foreach ($siteRoots as $siteRoot) {
+            $protocol = self::getProtocolForDomain($siteRoot->getMainDomain(), $client);
+            $sitesMap[] = [
+                'rootId' => $siteRoot->getRootId(),
+                'protocol' => $protocol,
+                'domain' => $siteRoot->getMainDomain()
+            ];
+        }
+
+        return $sitesMap;
+    }
+
+    /**
+     * Test https for a domain name and returns either https or http depending on the server answer
+     * @param $domain
+     * @param \Zend_Http_Client|null $client
+     * @return string
+     */
+    private function getProtocolForDomain($domain, \Zend_Http_Client $client = null)
+    {
+        if (!$client) {
+            $client = new \Zend_Http_Client();
+        }
+        $client->setUri('https://' . $domain);
+        try {
+            $client->request();
+            $protocol = $client->getLastResponse()->getStatus() === 200 ? 'https' : 'http';
+        } catch (\Exception $e) {
+            $protocol = 'http';
+        }
+
+        return $protocol;
     }
 
     /**
@@ -100,6 +177,11 @@ class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\Plugin
 
             $route = Staticroute::getByName('sitemap');
             $route->delete();
+
+            // Remove config file
+            if (file_exists(self::CONFIGURATION_FILE)) {
+                unlink(self::CONFIGURATION_FILE);
+            }
 
             return "Sitemap plugin is successfully uninstalled";
         }

--- a/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
+++ b/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
@@ -125,6 +125,7 @@ class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\Plugin
         $defaultDomain = Config::getSystemConfig()->get("general")->get("domain");
         $sitesMap[] = [
             'rootId' => 1,
+            'rootPath' => '',
             'protocol' => self::getProtocolForDomain($defaultDomain, $client),
             'domain' => $defaultDomain
         ];
@@ -139,6 +140,7 @@ class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\Plugin
             $protocol = self::getProtocolForDomain($siteRoot->getMainDomain(), $client);
             $sitesMap[] = [
                 'rootId' => $siteRoot->getRootId(),
+                'rootPath' => trim($siteRoot->getRootPath(), '/'),
                 'protocol' => $protocol,
                 'domain' => $siteRoot->getMainDomain()
             ];

--- a/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
+++ b/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
@@ -30,6 +30,7 @@ use Pimcore\Model\Staticroute;
 class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\PluginInterface
 {
     const MAINTENANCE_JOB_GENERATE_SITEMAP = "create-sitemap";
+    const SITEMAP_FOLDER = '/var/plugins/Sitemap';
 
     /**
      * {@inheritdoc}
@@ -78,6 +79,9 @@ class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\Plugin
                 ->setController('sitemap')
                 ->setAction('view')
                 ->save();
+
+            // Create sitemap folder
+            mkdir(PIMCORE_WEBSITE_PATH . self::SITEMAP_FOLDER, 0777, true);
 
             return "Sitemap plugin successfully installed";
         }

--- a/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
+++ b/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
@@ -30,8 +30,22 @@ use Byng\Pimcore\Sitemap\Generator\SitemapGenerator;
 class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\PluginInterface
 {
     const MAINTENANCE_JOB_GENERATE_SITEMAP = "create-sitemap";
-    const SITEMAP_FOLDER = '/var/plugins/Sitemap';
-    const CONFIGURATION_FILE = PIMCORE_WEBSITE_PATH . SitemapPlugin::SITEMAP_FOLDER . '/config.xml';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($jsPaths = null, $cssPaths = null)
+    {
+        parent::__construct($jsPaths, $cssPaths);
+
+        // Define constants (if not already defined in the startup.php)
+        if (!defined('SITEMAP_PLUGIN_FOLDER')) {
+            define('SITEMAP_PLUGIN_FOLDER', PIMCORE_WEBSITE_VAR . '/plugins/sitemap');
+        }
+        if (!defined('SITEMAP_CONFIGURATION_FILE')) {
+            define('SITEMAP_CONFIGURATION_FILE', SITEMAP_PLUGIN_FOLDER . '/config.xml');
+        }
+    }
 
     /**
      * {@inheritdoc}
@@ -94,7 +108,7 @@ class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\Plugin
     public static function isInstalled()
     {
         $property = PredefinedProperty::getByKey("sitemap_exclude");
-        return ($property && $property->getId() && file_exists(self::CONFIGURATION_FILE));
+        return ($property && $property->getId() && file_exists(SITEMAP_CONFIGURATION_FILE));
     }
 
 }

--- a/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
+++ b/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
@@ -20,6 +20,7 @@ use Pimcore\Model\Property\Predefined as PredefinedProperty;
 use Pimcore\Model\Schedule\Manager\Procedural as ProceduralScheduleManager;
 use Pimcore\Model\Schedule\Maintenance\Job as MaintenanceJob;
 use Byng\Pimcore\Sitemap\Generator\SitemapGenerator;
+use Pimcore\Model\Staticroute;
 
 /**
  * Sitemap Plugin
@@ -68,6 +69,16 @@ class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\Plugin
 
             $property->save();
 
+            // Create redirect rule
+            $route = Staticroute::create();
+            $route->setName('sitemap')
+                ->setPattern('/\/sitemap\.xml/')
+                ->setReverse('/sitemap.xml')
+                ->setModule('PimcoreSitemapPlugin')
+                ->setController('sitemap')
+                ->setAction('view')
+                ->save();
+
             return "Sitemap plugin successfully installed";
         }
 
@@ -82,6 +93,9 @@ class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\Plugin
         if (SitemapPlugin::isInstalled()) {
             $property = PredefinedProperty::getByKey("sitemap_exclude");
             $property->delete();
+
+            $route = Staticroute::getByName('sitemap');
+            $route->delete();
 
             return "Sitemap plugin is successfully uninstalled";
         }

--- a/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
+++ b/lib/Byng/Pimcore/Sitemap/SitemapPlugin.php
@@ -83,8 +83,11 @@ class SitemapPlugin extends PluginLib\AbstractPlugin implements PluginLib\Plugin
                 ->setAction('view')
                 ->save();
 
-            // Create sitemap folder
-            mkdir(PIMCORE_WEBSITE_PATH . self::SITEMAP_FOLDER, 0777, true);
+            // Create sitemap folder (if doesn't exist already)
+            if (!is_dir(PIMCORE_WEBSITE_PATH . self::SITEMAP_FOLDER)) {
+                mkdir(PIMCORE_WEBSITE_PATH . self::SITEMAP_FOLDER, 0777, true);
+            }
+
             // Get Sites FQDN map
             $sites = self::getSitesProtocolMap();
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,5 +24,6 @@
         <pluginNamespaces>
             <namespace>Byng\Pimcore\Sitemap</namespace>
         </pluginNamespaces>
+        <pluginXmlEditorFile>/website/var/plugins/Sitemap/config.xml</pluginXmlEditorFile>
     </plugin>
 </zend-config>

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,6 +24,6 @@
         <pluginNamespaces>
             <namespace>Byng\Pimcore\Sitemap</namespace>
         </pluginNamespaces>
-        <pluginXmlEditorFile>/website/var/plugins/Sitemap/config.xml</pluginXmlEditorFile>
+        <pluginXmlEditorFile>/website/var/plugins/sitemap/config.xml</pluginXmlEditorFile>
     </plugin>
 </zend-config>

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,6 +17,7 @@
         <!-- include paths relative to plugin-directory -->
         <pluginIncludePaths>
             <path>/PimcoreSitemapPlugin/lib</path>
+            <path>/PimcoreSitemapPlugin/controllers</path>
         </pluginIncludePaths>
 
         <!-- namespaces to register with autoloader-->


### PR DESCRIPTION
When you use the [multisite function of Pimcore](https://www.pimcore.org/wiki/pages/viewpage.action?pageId=14551657) the generated sitemap.xml has to be specific to each subsite.
Furthermore, it should include the domain of the site, and not the global domain (or Google will start to index pages on the wrong website).
## Summary

This PR provides the following changes:
- Generating one sitemap.xml for each available site
- Using a controller (and staticroute) to select the right sitemap to display depending on the current domain
- Notify Google for every updated sitemap

Its major limitation is I found no standardized way to know the protocol used for every subsite (http or https), it seems some developers use a custom property on the website but there is no way to infer it. I assumed all the websites should use https, since the admin interface is available on the same domain _by default_, and everywhere there is a login form we should use https. But if you know any way to know it for sure, i'd really like to remove [that static part of the code](https://github.com/byng-systems/pimcore-sitemap-plugin/pull/6/files#diff-71d0e7681cf36c448120f554e8c70f94R107).
## How to install:
- on a fresh install, this is a regular plugin installation
- if you already have the plugin installed, you have to remove the `sitemap.xml` file on your root installation to be sure the request is processed by pimcore, not served by the http server
## Feedback needed !

I am fairly new to Pimcore, so everything might not be 100% optimized. The documentation being sometimes sporadic, I suppose there are some hidden tricks I don't know about 😄 
Also, I tested it only with our Pimcore website, which runs under 3.1.1.

I used some PHP 5.4+ codestyle (ternary operators, short array notation, etc.) => I suppose this is no major issue, since [composer.json](https://github.com/byng-systems/pimcore-sitemap-plugin/blob/16bf606d48c4bfd1ebfed39f0f48b8e96eb503c2/composer.json) requires 5.5+ ?
